### PR TITLE
Mobile first flexbox grid, smaller gutters

### DIFF
--- a/template/assets/css/base/_grid.scss
+++ b/template/assets/css/base/_grid.scss
@@ -21,11 +21,6 @@ body.full-width .wrapper {
   margin-left:  -$gutter;
   margin-right: -$gutter;
   overflow: hidden;
-
-  @include respond-to(med) {
-    margin-left:  -$gutter*2;
-    margin-right: -$gutter*2;
-  }
 }
 .row:before, .row:after {
   content: '';
@@ -44,11 +39,6 @@ body.full-width .wrapper {
     padding-left:  $gutter;
     padding-right: $gutter;
     min-height: 1px;
-
-    @include respond-to(med) {
-      padding-left:  $gutter*2;
-      padding-right: $gutter*2;
-    }
   }
 }
 @for $i from 1 through 11 {
@@ -147,65 +137,46 @@ body.full-width .wrapper {
 
 // Flexbox Grid
 
-.flex-center {
+.flex-grid {
   display: flex;
+}
+.flex-grid > * {
+  flex: 1;
+}
+.flex-center {
   align-items: center;
   justify-content: center;
   height: 100%;
 }
-.flex-row {
-  display: flex;
-  justify-content: center;
-  flex-flow: row wrap;
-}
-.flex-row > * {
-  flex: 1;
-  margin-right: $gutter*2;
-  min-width: 0;
-}
-.flex-row > *:last-child {
-  margin-right: 0;
-}
 .sml-flex-col {
   flex-direction: column;
 }
-.sml-flex-col > * {
-  margin-right: 0;
-}
-.med-flex-row {
-  @include respond-to(med) {
-    flex-direction: row;
-  }
-}
-.med-flex-row > * {
-  @include respond-to(med) {
-    margin-right: $gutter*2;
-  }
-}
-.lrg-flex-row {
-  @include respond-to(lrg) {
-    flex-direction: row;
-  }
-}
-@for $i from 1 through 4 {
-  .sml-flex-#{$i} {
-    flex: $i;
-  }
-}
-@include respond-to(med) {
-  @for $i from 1 through 4 {
-    .med-flex-#{$i} {
-      flex: $i;
+
+@mixin flex-row($content) {
+  @include respond-to($content) {
+    .#{$content}-flex-row {
+      flex-direction: row;
+      flex-flow: row wrap;
+      justify-content: center;
+    }
+    .#{$content}-flex-row > * {
+      margin-right: $gutter;
+      min-width: 0;
+    }
+    .#{$content}-flex-row > *:last-child {
+      margin-right: 0;
+    }
+    @for $i from 1 through 4 {
+      .#{$content}-flex-#{$i} {
+        flex: $i;
+      }
     }
   }
 }
-@include respond-to(lrg) {
-  @for $i from 1 through 4 {
-    .lrg-flex-#{$i} {
-      flex: $i;
-    }
-  }
-}
+@include flex-row(sml)
+@include flex-row(med)
+@include flex-row(lrg)
+
 .flex-fixed-height {
   flex-grow: 0;
 }

--- a/template/components/ActionNetworkForm.vue
+++ b/template/components/ActionNetworkForm.vue
@@ -39,17 +39,17 @@
     <form @submit.prevent="submitForm()" v-if="!hasSigned"
           class="sml-push-y2 med-push-y3">
       <p class="text-warn" v-if="errorMessage">{{ errorMessage }}</p>
-      <div class="flex-row">
+      <div class="flex-grid sml-flex-row">
         <input v-model="name" type="text" placeholder="Name*" required>
         <input v-model="email" type="email" placeholder="Email*" required>
-      </div> <!-- .flex-row -->
-      <div class="flex-row sml-push-y2">
+      </div> <!-- .flex-grid -->
+      <div class="flex-grid sml-flex-row sml-push-y1">
         <input v-model="address" type="text" placeholder="Address"
                class="sml-flex-4">
         <input v-model="zipCode" type="tel" placeholder="ZIP Code">
-      </div> <!-- .flex-row -->
+      </div> <!-- .flex-grid -->
 
-      <button class="btn btn-block sml-push-y2 med-push-y3" :disabled="isSending">
+      <button class="btn btn-block sml-push-y1" :disabled="isSending">
         <span v-if="isSending">
           Sending...
         </span>

--- a/template/components/CallFormModal.vue
+++ b/template/components/CallFormModal.vue
@@ -8,7 +8,7 @@
       directly with your lawmaker&rsquo;s office.
     </p>
     <p v-if="errorMessage" class="text-warn sml-push-y2">{{ errorMessage }}</p>
-    <form @submit.prevent="submitForm()" class="flex-row sml-push-y2">
+    <form @submit.prevent="submitForm()" class="flex-grid sml-flex-row sml-push-y2">
       <input class="phone sml-flex-2" type="tel" placeholder="Phone Number*"
              v-model.trim="phone" required>
       <input class="zip" type="tel" placeholder="ZIP Code*"

--- a/template/components/GalleryHeader.vue
+++ b/template/components/GalleryHeader.vue
@@ -8,7 +8,7 @@
           </a>
         </div> <!-- .c -->
         <div class="sml-c6 med-c4">
-          <div class="flex-row sml-push-y-half">
+          <div class="flex-grid sml-flex-row sml-push-y-half">
             <p class="text-meta text-right sml-hide lrg-show">
               <strong>Filter by state:</strong>
             </p>
@@ -20,7 +20,7 @@
                 </option>
               </select>
             </form>
-          </div> <!-- .flex-row -->
+          </div> <!-- .flex-grid -->
         </div> <!-- .c -->
       </div> <!-- .row -->
     </div> <!-- .wrapper -->

--- a/template/components/PrintTheLetter.vue
+++ b/template/components/PrintTheLetter.vue
@@ -4,7 +4,7 @@
     <p class="sml-push-y2 med-push-y3">
       Select your state below to print out the letter.
     </p>
-    <div class="flex-row sml-flex-col med-flex-row sml-push-y3">
+    <div class="flex-grid sml-flex-col med-flex-row sml-push-y3">
       <select v-model="selectedState" class="sml-flex-2">
         <option :value="null">Select your state</option>
         <option v-for="(name, abbr) in states" :key="abbr" :value="abbr">
@@ -16,7 +16,7 @@
               @click.prevent="printLetter()">
         Print the Letter
       </button>
-    </div> <!-- .flex-row -->
+    </div> <!-- .flex-grid -->
   </div>
 </template>
 

--- a/template/components/QuoteScroller.vue
+++ b/template/components/QuoteScroller.vue
@@ -45,12 +45,12 @@
 </style>
 
 <template>
-  <div class="quotes-wrapper flex-row flex-center">
+  <div class="quotes-wrapper flex-grid sml-flex-row flex-center">
     <a class="arrow" @click.prevent="prev">
       <img src="~assets/images/arrow-left.svg" alt="Previous" class="grid-center"/>
     </a>
     <transition name="fade" mode="out-in">
-      <div :key="`slide-${activeSlide}`">
+      <div :key="`slide-${activeSlide}`" class="sml-pad-x1">
         <blockquote>{{ quotes[activeSlide].text }}</blockquote>
         <p class="text-brand">{{ quotes[activeSlide].source }}</p>
       </div>

--- a/template/components/SelfieForm.vue
+++ b/template/components/SelfieForm.vue
@@ -39,8 +39,8 @@
       <form @submit.prevent="submitForm()" class="sml-push-y2 med-push-y3">
         <div class="sml-push-y2 med-push-y3 sml-pad-2 fill-grey is-rounded-top">
           <p class="text-warn text-center" v-if="errorMessage">{{ errorMessage }}</p>
-          <div class="flex-row sml-flex-col med-flex-row" :class="{'sml-push-y-half': errorMessage}">
-            <div class="">
+          <div class="flex-grid sml-flex-col med-flex-row" :class="{'sml-push-y-half': errorMessage}">
+            <div>
               <div class="preview-container grid-center is-rounded"
                    :style="{ width: previewWidth, height: previewHeight }"
                    @click="clickPreview">
@@ -58,7 +58,7 @@
                 <img v-show="!photoSource" src="~/assets/images/photo-frame.png" alt="" ref="overlay" class="overlay">
               </div>
 
-              <div class="flex-row sml-push-y1">
+              <div class="flex-grid sml-flex-row sml-push-y1">
                 <div v-if="hasWebcam">
                   <a class="btn btn-block btn-sml"
                      @click.prevent="startLiveView()"
@@ -79,17 +79,17 @@
                          :disabled="isCapturing"
                          ref="fileInput">
                 </div>
-              </div> <!-- .flex-row -->
-            </div> <!-- .c -->
-            <div class="flex-row sml-flex-col sml-push-y2 med-push-y0">
+              </div> <!-- .flex-grid -->
+            </div> <!-- flex column -->
+            <div class="flex-grid sml-flex-col sml-push-y2 med-push-y0">
               <label class="flex-fixed-height sml-pad-1 sml-pad-x2 fill-grey-light is-rounded-top">
                 <h5>Your Net Neutrality thoughts:</h5>
               </label>
               <textarea v-model="comment" class="flat-top"
                         placeholder="I care about Net Neutrality because...">
               </textarea>
-            </div> <!-- .c -->
-          </div> <!-- .row -->
+            </div> <!-- .flex-grid -->
+          </div> <!-- .flex-grid -->
         </div> <!-- .fill -->
         <div class="sml-pad-2 fill-grey-dark is-rounded-bottom">
           <button class="btn btn-block"

--- a/template/components/SocialShareButtons.vue
+++ b/template/components/SocialShareButtons.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex-row text-center">
+  <div class="flex-grid sml-flex-row text-center">
     <ShareButton
       network="twitter"
       :url="url"
@@ -12,7 +12,7 @@
       :should-display-icon="false"
       class="btn-sml btn-block"
       @click.native="$trackClick('facebook_share_button')" />
-  </div> <!-- .flex-row -->
+  </div> <!-- .flex-grid -->
 </template>
 
 <script>


### PR DESCRIPTION
Taking the time to make the flexbox grid properly mobile first with no overwrites.

`flex-row` is now:
`flex-grid sml-flex-row`

`flex-row sml-flex-col med-flex-row` is now:
`flex-grid sml-flex-col med-flex-row` (and there's no zero-ing out and adding back of margins)

Flex sizing `sml-flex-1 med-flex-3` works as it did previously.

Design has been preferring smaller grid gutters overall, so the default gutter is now `$gutter` instead of `$gutter*2` on med+ for both the flexbox and base float grids. We can always change this back per project. Smaller grid gutters example:
<img width="810" alt="screen shot 2019-01-02 at 12 22 05 pm" src="https://user-images.githubusercontent.com/171493/50603617-25438080-0e89-11e9-908f-352252c1afc1.png">
